### PR TITLE
Updated <meta name="viewport"> tag

### DIFF
--- a/views/404.ejs
+++ b/views/404.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Politivector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Politivector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">

--- a/views/plans.ejs
+++ b/views/plans.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Politivector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">

--- a/views/questions.ejs
+++ b/views/questions.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Politivector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Politivector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">


### PR DESCRIPTION
Added `height=device-height` to the `<meta name="viewport">` tag. This should fix the mobile overlapping issue. If not, the CSS needs to be updated.